### PR TITLE
feat: persist theme toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,11 @@
       };
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      if (localStorage.getItem('theme') === 'dark') {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
     <title>React App</title>
   </head>
   <body>

--- a/src/components/ThemeButton.js
+++ b/src/components/ThemeButton.js
@@ -2,17 +2,21 @@ import React, { useState, useEffect } from 'react';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 
+// Toggle between light and dark themes and persist the user's choice
 const ThemeButton = () => {
-  const [isDark, setIsDark] = useState(
-    () => window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-  );
+  const [isDark, setIsDark] = useState(() => {
+    const stored = localStorage.getItem('theme');
+    return stored ? stored === 'dark' : false;
+  });
 
   useEffect(() => {
     const root = document.documentElement;
     if (isDark) {
       root.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
     } else {
       root.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
     }
   }, [isDark]);
 


### PR DESCRIPTION
## Summary
- save theme preference in localStorage and apply it on load
- add startup script to respect saved dark mode

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@mui/icons-material/LightMode')*

------
https://chatgpt.com/codex/tasks/task_e_68b16a4269fc8328a74e485ca34d92be